### PR TITLE
check to see if debug-name is an atom before treating it as a list

### DIFF
--- a/src/naming-sbcl.lisp
+++ b/src/naming-sbcl.lisp
@@ -80,6 +80,8 @@ will be: package.foo.bar.baz
                                        (symbol-name debug-name)))))
         debug-name)
       (cond 
+        ((atom debug-name)
+         (string debug-name))
         ((member (first debug-name) '(flet labels lambda))
          (include-block-debug-name? (second debug-name)))
         ((eq 'labels (first debug-name))


### PR DESCRIPTION
 * a recent change to the SBCL internals allows for debug-name to be
   an atom that is coerceable to a string, rather than just a list and
   the code was previously assuming that debug-name was a list.