### PR TITLE
watcher: wrap release-lock in ignore-errors

### DIFF
--- a/src/watcher.lisp
+++ b/src/watcher.lisp
@@ -88,7 +88,8 @@
                       (error (e)
                         (log-error :logger logger "Error in hierarchy watcher thread:~%~A" e))))
                (with-hierarchies-lock
-                 #+ecl (bt:release-lock *stop-lock*)
+                 ;; lock might not have been acquired (i.e terminate-thread was called)
+                 #+ecl (ignore-errors (bt:release-lock *stop-lock*))
                  (setf *watcher-thread* nil))
                (%with-local-interrupts (log-info :logger logger "Hierarchy watcher thread ended"))))))
        :name "Hierarchy Watcher"


### PR DESCRIPTION
When we terminate application unwind-protect calls protected forms without
acquire-ing lock. Trying to release not acquired lock will lead to a condtion
which drops us in the debugger, what prevents correct program termination.