### PR TITLE
readded semaphores from bt

### DIFF
--- a/src/watcher.lisp
+++ b/src/watcher.lisp
@@ -32,14 +32,10 @@
 (defmacro with-logged-problems (context &body body)
   `(call-with-logged-problems ',context (lambda () ,@body)))
 
-#-ecl (defvar *stop-cv* (bt:make-condition-variable :name "Log4CL stop condition variable"))
-#-ecl (defvar *stop-watcher* nil)
-(defvar *stop-lock* (bt:make-lock "Log4CL stop lock"))
+(defvar *stop-semaphore* (bt:make-semaphore :name "stop-log4cl"))
 
 (defun start-hierarchy-watcher-thread ()
   (unless *watcher-thread*
-    #-ecl (setf *stop-watcher* nil)
-    #+ecl (bt:acquire-lock *stop-lock*)
     (let ((logger (make-logger '(log4cl))))
       (bordeaux-threads:make-thread
        (lambda ()
@@ -53,24 +49,14 @@
                 (handler-case
                     (progn
                       (log-info :logger logger "Hierarchy watcher started")
-                      (loop for *watcher-event-time* = (get-universal-time)
-                            do (hierarchy-watcher-once)
-                            until
-                               #-ecl ; timeout on cv signals error in ECL 16.1.3
-                               (bt:with-lock-held (*stop-lock*)
-                                 (bt:condition-wait *stop-cv* *stop-lock*
-                                                    :timeout *hierarchy-watcher-heartbeat*)
-                                 *stop-watcher*)
-                               #+ecl
-                               (handler-case
-                                   (bt:with-timeout (*hierarchy-watcher-heartbeat*)
-                                     (bt:acquire-lock *stop-lock*))
-                                 (serious-condition () nil))))
+                      (loop
+                         for *watcher-event-time* = (get-universal-time)
+                         do (hierarchy-watcher-once)
+                         until (bt:wait-on-semaphore *stop-semaphore*
+                                                     :timeout *hierarchy-watcher-heartbeat*)))
                   (error (e)
                     (log-error :logger logger "Error in hierarchy watcher thread:~%~A" e)))
              (with-hierarchies-lock
-               ;; lock might not have been acquired (i.e terminate-thread was called)
-               #+ecl (ignore-errors (bt:release-lock *stop-lock*))
                (setf *watcher-thread* nil))
              (log-info :logger logger "Hierarchy watcher thread ended"))))
        :name "Hierarchy Watcher"
@@ -103,11 +89,8 @@
 (defun stop-hierarchy-watcher-thread ()
   (let ((thread (with-hierarchies-lock *watcher-thread*)))
     (when thread
-      (with-logged-problems '(stop-hierarchy-watcher-thread :stop-thread)
-        #-ecl (bt:with-lock-held (*stop-lock*)
-                (setf *stop-watcher* t)
-                (bt:condition-notify *stop-cv*))
-        #+ecl (bt:release-lock *stop-lock*))
+      (with-logged-problems '(stop-hierarchy-watcher-thread :destroy-thread)
+        (bt:signal-semaphore *stop-semaphore*))
       (with-logged-problems '(stop-hierarchy-watcher-thread :join-thread)
         (bt:join-thread thread)))))
 


### PR DESCRIPTION
- *blindly* reverted changes from:
https://github.com/sharplispers/log4cl/commit/1c7f44e44b8548e5fa3e863b2de301489a42b8ef

to enable again use of semaphores.

Tested only on SBCL 1.4.10 on linux x86-64.