### PR TITLE
Allow :debug syslog level recognition

### DIFF
--- a/src/appender/syslog-appender-cffi.lisp
+++ b/src/appender/syslog-appender-cffi.lisp
@@ -26,5 +26,5 @@
       (:error :err)
       (:warn  :warning)
       (:info  :info)
-      ((:debu1 :debu2 :debu3 :debu4 :debu5 :debu6 :debu7 :debu8 :debu9)
+      ((:debug :debu1 :debu2 :debu3 :debu4 :debu5 :debu6 :debu7 :debu8 :debu9)
        :debug))))

--- a/src/appender/syslog-appender-sbcl.lisp
+++ b/src/appender/syslog-appender-sbcl.lisp
@@ -28,5 +28,5 @@
       (:error sb-posix:log-err)
       (:warn  sb-posix:log-warning)
       (:info  sb-posix:log-info)
-      ((:debu1 :debu2 :debu3 :debu4 :debu5 :debu6 :debu7 :debu8 :debu9)
+      ((:debug :debu1 :debu2 :debu3 :debu4 :debu5 :debu6 :debu7 :debu8 :debu9)
        sb-posix:log-debug))))


### PR DESCRIPTION
If you use the syslog appender and (log:debug "foo") it signals a condition and disables the appender.  Add :debug to to list of recognized levels.