### PR TITLE
log4cl syslog appender eventually crashes long running applications

### DIFF
--- a/src/appender/syslog-appender-sbcl.lisp
+++ b/src/appender/syslog-appender-sbcl.lisp
@@ -12,12 +12,14 @@
          (message
            (with-output-to-string (stream)
              (layout-to-stream layout stream logger level log-func))))
-    (sb-posix:openlog (syslog-appender-name appender)
-                      (logior sb-posix:log-user
-                              (if (syslog-appender-include-pid? appender)
-                                  sb-posix:log-pid 0)))
-    (sb-posix:syslog syslog-level "~A" message)
-    (sb-posix:closelog)))
+    (unwind-protect
+      (progn
+        (sb-posix:openlog (syslog-appender-name appender)
+                          (logior sb-posix:log-user
+                                  (if (syslog-appender-include-pid? appender)
+                                      sb-posix:log-pid 0)))
+        (sb-posix:syslog syslog-level "~A" message))
+      (sb-posix:closelog))))
 
 ;; Utility functions
 

--- a/src/appender/syslog-appender.lisp
+++ b/src/appender/syslog-appender.lisp
@@ -7,7 +7,7 @@
 
 (in-package #:log4cl)
 
-(defclass syslog-appender (appender)
+(defclass syslog-appender (serialized-appender)
   ((name :initarg :name :type string
          :accessor syslog-appender-name)
    (include-pid? :initarg :include-pid? :type boolean


### PR DESCRIPTION
The appender needs to be serialized and unwind-protect'ed, otherwise there are potential file descriptor leaks and internal openlog(3),syslog(3), closelog(3) state corruption.